### PR TITLE
Correct issue time to use UTC

### DIFF
--- a/SampleIdentityTokenLayer/SampleIdentityTokenLayer/Controllers/LayerController.cs
+++ b/SampleIdentityTokenLayer/SampleIdentityTokenLayer/Controllers/LayerController.cs
@@ -57,7 +57,7 @@ namespace SampleIdentityTokenLayer.Controllers
         public string GenerateIdentifyToken(string userid, string nonce)
         {
             var utc0 = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-            var issueTime = DateTime.Now;
+            var issueTime = DateTime.UtcNow;
             var iat = (int)issueTime.Subtract(utc0).TotalSeconds;//issues time in second
             var exp = (int)issueTime.AddMinutes(60).Subtract(utc0).TotalSeconds;//expired time in second
             var jwtHeader = new JwtHeader


### PR DESCRIPTION
The generated token fails the validation tool stating the issue date has expired.
https://developer.layer.com/projects/tools

Switching the issue date to UTC corrects the issue.